### PR TITLE
Fixes some setups of unwrapped % in yml breaking site

### DIFF
--- a/_config/extension.yml
+++ b/_config/extension.yml
@@ -2,4 +2,4 @@ SilverStripe\Core\Injector\Injector:
   SilverStripe\View\Requirements_Backend:
     properties:
       MinifyCombinedFiles: true
-      Minifier: %$Axllent\Minifier\Minifier
+      Minifier: '%$Axllent\Minifier\Minifier'


### PR DESCRIPTION
On some setups there is the following error:

    Fatal error: Uncaught Symfony\Component\Yaml\Exception\ParseException: The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 5 (near "Minifier: %$Axllent\Minifier\Minifier").

Wrapping the string with single quotes fixes this issue.